### PR TITLE
Fix unsupported render texture format exception on mobile vulkan devices

### DIFF
--- a/Packages/com.verasl.water-system/Scripts/Rendering/PlanarReflections.cs
+++ b/Packages/com.verasl.water-system/Scripts/Rendering/PlanarReflections.cs
@@ -243,8 +243,10 @@ namespace UnityEngine.Rendering.LWRP
             var res = ReflectionResolution(camera, LightweightRenderPipeline.asset.renderScale);
             if (m_ReflectionTexture == null)
             {
+                bool useRGB111110 = SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.RGB111110Float);
+                RenderTextureFormat hdrFormat = (useRGB111110) ? RenderTextureFormat.RGB111110Float : RenderTextureFormat.DefaultHDR;
                 m_ReflectionTexture = RenderTexture.GetTemporary(res.x, res.y, 16,
-                    GraphicsFormatUtility.GetGraphicsFormat(RenderTextureFormat.RGB111110Float, true));
+                    GraphicsFormatUtility.GetGraphicsFormat(hdrFormat, true));
             }
 
             m_ReflectionCamera.targetTexture = m_ReflectionTexture;


### PR DESCRIPTION
PlanarReflections render texture causes unsupported format exceptions when ran on android devices with Vulkan API.
Fixes: https://issuetracker.unity3d.com/product/unity/issues/guid/1113057/
Devices that reproduce (with Adreno GPU): Google Pixel 2, S9, Note9.