### PR TITLE
Enable test script defines and force no batch mode during test runs

### DIFF
--- a/Assets/scenes/Testing/benchmark_island-static.unity
+++ b/Assets/scenes/Testing/benchmark_island-static.unity
@@ -207,9 +207,14 @@ PrefabInstance:
       propertyPath: field of view
       value: 60
       objectReference: {fileID: 0}
+    - target: {fileID: 7003470173341666317, guid: 530da10d6c4d9442e9e8d5eeb77a25d8,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 530da10d6c4d9442e9e8d5eeb77a25d8, type: 3}
---- !u!84 &378685783
+--- !u!84 &802330244
 RenderTexture:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -816,22 +816,22 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLWasmStreaming: 0
   scriptingDefineSymbols:
-    1: 
-    4: 
-    7: 
-    13: 
-    14: 
-    17: 
-    18: 
-    19: 
-    21: 
-    23: 
-    24: 
-    25: 
-    26: 
-    27: 
-    28: 
-    29: 
+    1: URP;USE_CUSTOM_METADATA
+    4: URP;USE_CUSTOM_METADATA
+    7: URP;USE_CUSTOM_METADATA
+    13: URP;USE_CUSTOM_METADATA
+    14: URP;USE_CUSTOM_METADATA
+    17: URP;USE_CUSTOM_METADATA
+    18: URP;USE_CUSTOM_METADATA
+    19: URP;USE_CUSTOM_METADATA
+    21: URP;USE_CUSTOM_METADATA
+    23: URP;USE_CUSTOM_METADATA
+    24: URP;USE_CUSTOM_METADATA
+    25: URP;USE_CUSTOM_METADATA
+    26: URP;USE_CUSTOM_METADATA
+    27: URP;USE_CUSTOM_METADATA
+    28: URP;USE_CUSTOM_METADATA
+    29: URP;USE_CUSTOM_METADATA
   platformArchitecture:
     iPhone: 1
   scriptingBackend:

--- a/TestRunnerOptions.json
+++ b/TestRunnerOptions.json
@@ -1,0 +1,3 @@
+{
+    "disableBatchMode": true
+}


### PR DESCRIPTION
My goal is to prevent as little upfront configuration for BoatAttack in order to run our perf tests. I'd like to add these script defines to the project settings in order to enable a few packages we use for emitting additional metadata for the perf tests. I've spent enough time trying to do this programmatically. I have working code that adds them, but we can't rely on a complete domain reload consistently happening before we load in our packages.