### PR TITLE
add link.xml so we don't strip our test assemblies.

### DIFF
--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -1,0 +1,16 @@
+<linker>
+       <assembly fullname="Unity.PerformanceTesting" preserve="all"/>
+	   <assembly fullname="Unity.GraphicTests.Performance.Runtime" preserve="all"/>
+	   <assembly fullname="Unity.PerformanceTesting.Editor" preserve="all"/>
+	   <assembly fullname="Unity.GraphicTests.Performance.Editor" preserve="all"/>
+	   <assembly fullname="UnityEngine.TestTools.Graphics" preserve="all"/>
+	   <assembly fullname="Unity.GraphicTests.Performance.Universal.Runtime" preserve="all"/>	
+       <assembly fullname="com.unity.test.performance.runtimesettings" preserve="all"/>		
+	   <assembly fullname="com.unity.test.metadata-manager" preserve="all"/>		
+	   <assembly fullname="nunit.framework" preserve="all"/>		
+	   <assembly fullname="Newtonsoft.Json" preserve="all"/>		
+	   <assembly fullname="Unity.RenderPipelines.Core.Runtime" preserve="all"/>	   
+	   <assembly fullname="com.unity.cliprojectsetup" preserve="all"/>	
+	   <assembly fullname="Unity.Addressables.Editor" preserve="all"/>	
+	   <assembly fullname="UnityEngine.TestRunner" preserve="all"/>	
+</linker>

--- a/Assets/link.xml.meta
+++ b/Assets/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7211b8db245a62242967a9cf711c7660
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add a link.xml file in order to ensure our test assemblies are not stripped during IL2CPP builds.