### PR TITLE
Water URP 10, Unity 2020.2 fix

### DIFF
--- a/Packages/com.verasl.water-system/Shaders/WaterCommon.hlsl
+++ b/Packages/com.verasl.water-system/Shaders/WaterCommon.hlsl
@@ -239,9 +239,10 @@ half4 WaterFragment(WaterVertexOutput IN) : SV_Target
 	// Fresnel
 	half fresnelTerm = CalculateFresnelTerm(IN.normal, IN.viewDir.xyz);
 	//return fresnelTerm.xxxx;
-
+	
     BRDFData brdfData;
-    InitializeBRDFData(half3(0, 0, 0), 0, half3(1, 1, 1), 0.95, 1, brdfData);
+    half alphaInOut = 1;
+    InitializeBRDFData(half3(0, 0, 0), 0, half3(1, 1, 1), 0.95, alphaInOut, brdfData);
 	half3 spec = DirectBDRF(brdfData, IN.normal, mainLight.direction, IN.viewDir) * shadow * mainLight.color;
 #ifdef _ADDITIONAL_LIGHTS
     uint pixelLightCount = GetAdditionalLightsCount();

--- a/Packages/com.verasl.water-system/Shaders/WaterCommon.hlsl
+++ b/Packages/com.verasl.water-system/Shaders/WaterCommon.hlsl
@@ -239,7 +239,7 @@ half4 WaterFragment(WaterVertexOutput IN) : SV_Target
 	// Fresnel
 	half fresnelTerm = CalculateFresnelTerm(IN.normal, IN.viewDir.xyz);
 	//return fresnelTerm.xxxx;
-	
+
     BRDFData brdfData;
     half alphaInOut = 1;
     InitializeBRDFData(half3(0, 0, 0), 0, half3(1, 1, 1), 0.95, alphaInOut, brdfData);


### PR DESCRIPTION
This fixes pink water issues as (new?) InitializeBRDFData is:
```
inline void InitializeBRDFData(half3 albedo, half metallic, half3 specular, half smoothness, inout half alpha, out BRDFData outBRDFData)
```