### PR TITLE
benchmark loading on ios fix

### DIFF
--- a/Assets/Scripts/Editor/Benchmark/BenchmarkWindow.cs
+++ b/Assets/Scripts/Editor/Benchmark/BenchmarkWindow.cs
@@ -55,7 +55,7 @@ public class BenchmarkWindow : EditorWindow
         assetGUID = EditorPrefs.GetString(assetGuidKey);
         if (assetGUID == "")
             assetGUID = AssetDatabase.GUIDFromAssetPath("Assets/resources/benchmarksettings.asset").ToString();
-        
+
         _benchConfigData = AssetDatabase.LoadAssetAtPath<BenchmarkConfigData>(AssetDatabase.GUIDToAssetPath(assetGUID));
     }
 
@@ -227,8 +227,7 @@ public class BenchmarkWindow : EditorWindow
         options.locationPathName = $"Builds/Benchmark/{target:G}/BoatattackBenchmark{ext}";
         options.target = target;
         options.targetGroup = BuildPipeline.GetBuildTargetGroup(target);
-        options.options = BuildOptions.Development;
-        options.options = BuildOptions.AutoRunPlayer;
+        options.options |= (BuildOptions.Development | BuildOptions.AutoRunPlayer);
 
         var curTar = EditorUserBuildSettings.activeBuildTarget;
         if (target != curTar)

--- a/Assets/Scripts/GameSystem/AppSettings.cs
+++ b/Assets/Scripts/GameSystem/AppSettings.cs
@@ -77,7 +77,7 @@ namespace BoatAttack
             DontDestroyOnLoad(ConsoleCanvas);
             MainCamera = Camera.main;
         }
-        
+
         private void OnDisable()
         {
             SceneManager.sceneLoaded -= LevelWasLoaded;
@@ -255,7 +255,7 @@ namespace BoatAttack
             }
             yield return assetLoading;
         }
-        
+
         public static void ExitGame(string s = "null")
         {
             if(s != "null")
@@ -273,8 +273,7 @@ namespace BoatAttack
             if (args.Length <= 0) return;
             foreach (var argRaw in args)
             {
-                if (argRaw[0] != '-') continue;
-
+                if(string.IsNullOrEmpty(argRaw) || argRaw[0] != '-') continue;
                 var arg = argRaw.Split(':');
 
                 switch (arg[0])


### PR DESCRIPTION
unity bug 1298326
fix for boat attack being stuck on loading screen on ios, due to exception thrown when enabling AppSettings, resulting in the immediate disable, which removes "scene loaded" callback (thus preventing from switching to the level)