### PR TITLE
Graphics: Check B10G11R11 support for HDR format

### DIFF
--- a/Packages/com.verasl.water-system/Scripts/Rendering/PlanarReflections.cs
+++ b/Packages/com.verasl.water-system/Scripts/Rendering/PlanarReflections.cs
@@ -221,8 +221,8 @@ namespace UnityEngine.Rendering.Universal
             if (_reflectionTexture == null)
             {
                 var res = ReflectionResolution(cam, UniversalRenderPipeline.asset.renderScale);
-                const bool useHdr10 = true;
-                const RenderTextureFormat hdrFormat = useHdr10 ? RenderTextureFormat.RGB111110Float : RenderTextureFormat.DefaultHDR;
+                bool useHdr10 = RenderingUtils.SupportsRenderTextureFormat(RenderTextureFormat.RGB111110Float);
+                RenderTextureFormat hdrFormat = useHdr10 ? RenderTextureFormat.RGB111110Float : RenderTextureFormat.DefaultHDR;
                 _reflectionTexture = RenderTexture.GetTemporary(res.x, res.y, 16,
                     GraphicsFormatUtility.GetGraphicsFormat(hdrFormat, true));
             }


### PR DESCRIPTION
Some android-based GPU such as Adreno 540 (Quest, Pixel 2) [do not have linear render support for `B10G11R11_UFLOAT_PACK32`](http://vulkan.gpuinfo.org/displayreport.php?id=11350#formats).
In such cases, BoatAttack fails to display anything on screen and spits out exceptions. Additionally, the test runner will fail on these platforms.