### PR TITLE
Bump com.unity.memoryprofiler to 0.2.9-preview.3

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.inputsystem": "1.1.0-preview.2",
     "com.unity.mathematics": "1.2.1",
-    "com.unity.memoryprofiler": "0.2.9-preview.1",
+    "com.unity.memoryprofiler": "https://github.cds.internal.unity3d.com/unity/com.unity.memoryprofiler.git#fix-capture-metadata-compilation",
     "com.unity.render-pipelines.universal": "10.2.2",
     "com.unity.textmeshpro": "3.0.3",
     "com.unity.timeline": "1.4.3",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.inputsystem": "1.1.0-preview.2",
     "com.unity.mathematics": "1.2.1",
-    "com.unity.memoryprofiler": "https://github.cds.internal.unity3d.com/unity/com.unity.memoryprofiler.git#fix-capture-metadata-compilation",
+    "com.unity.memoryprofiler": "0.2.9-preview.3",
     "com.unity.render-pipelines.universal": "10.2.2",
     "com.unity.textmeshpro": "3.0.3",
     "com.unity.timeline": "1.4.3",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.inputsystem": "1.1.0-preview.2",
     "com.unity.mathematics": "1.2.1",
-    "com.unity.memoryprofiler": "0.2.6-preview.1",
+    "com.unity.memoryprofiler": "0.2.9-preview.1",
     "com.unity.render-pipelines.universal": "10.2.2",
     "com.unity.textmeshpro": "3.0.3",
     "com.unity.timeline": "1.4.3",


### PR DESCRIPTION
## Changelog

- Bumped com.unity.memoryprofiler from `0.2.6-preview.1` to `0.2.9-preview.3`. This is to avoid some issues reported in [this thread](https://unity.slack.com/archives/CHVTMBEF5/p1621587376026300).

## Testing
Checking that the graphics perf tests are now fixed:
https://yamato.cds.internal.unity3d.com/jobs/902-Graphics/tree/master/.yamato%252Furp_performance_boatattack-win-dx11.yml%2523URP_Performance_BoatAttack_Win_DX11_performance_playmode_editor_mono_Linear_trunk/6977604/job/pipeline