### PR TITLE
Disable depth testing for a screenspace shader

### DIFF
--- a/Assets/Shaders/UI/UIPanelFade.shader
+++ b/Assets/Shaders/UI/UIPanelFade.shader
@@ -19,6 +19,7 @@
         {
             Blend SrcAlpha OneMinusSrcAlpha
             ZWrite Off
+            ZTest Always
             Cull Off
 
             HLSLPROGRAM


### PR DESCRIPTION
Can fail depth test if the depth buffer is unintialized.