### PR TITLE
Wave struct stores float instead of half types. 

### DIFF
--- a/Packages/com.verasl.water-system/Shaders/GerstnerWaves.hlsl
+++ b/Packages/com.verasl.water-system/Shaders/GerstnerWaves.hlsl
@@ -5,11 +5,11 @@ uniform uint 	_WaveCount; // how many waves, set via the water component
 
 struct Wave
 {
-	half amplitude;
-	half direction;
-	half wavelength;
-	half2 origin;
-	half omni;
+	float amplitude;
+	float direction;
+	float wavelength;
+	float2 origin;
+	float omni;
 };
 
 #if defined(USE_STRUCTURED_BUFFER)


### PR DESCRIPTION
This fixes a bug on some platforms where half types in structBuffers are stored as 16 bits, but the data uploaded from the CPU are 32 bits floats. This would result in the water geometry not appearing on screen.

https://fogbugz.unity3d.com/f/cases/1382009/