### PR TITLE
Disable com.unity.build-report-inspector package

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "1.19.11",
-    "com.unity.build-report-inspector": "0.2.2-preview",
     "com.unity.burst": "1.4.11",
     "com.unity.cinemachine": "2.6.11",
     "com.unity.ide.rider": "2.0.7",


### PR DESCRIPTION
In https://unity.slack.com/archives/C0190LFB47K/p1658397921683369 it was agreed to disable an offending package for this project, as it fails our pipelines ([context](https://unity.slack.com/archives/CFZERNTS7/p1657111266195959)).

We will discuss with @sophia about if we still need this package for the project, and if yes, @lukas.michnevic will be able to push a fix in late August.

### Testing
The change has been tested in https://github.cds.internal.unity3d.com/unity/ant-graphics-ci/pull/323 🟢 