### PR TITLE
Fix background loading priority to high in the LoadingScreen

### DIFF
--- a/Assets/Scripts/UI/LoadingScreen.cs
+++ b/Assets/Scripts/UI/LoadingScreen.cs
@@ -10,7 +10,7 @@ public class LoadingScreen : MonoBehaviour
 
     private void OnEnable()
     {
-        Application.backgroundLoadingPriority = ThreadPriority.Low;
+        Application.backgroundLoadingPriority = ThreadPriority.High;
     }
 
     private void OnDestroy()


### PR DESCRIPTION
Application.backgroundLoadingPriority should be ThreadPriority.High, So it can load as much data as possible.